### PR TITLE
Link to rave-level from upgrade table

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To upgrade, please consult the following table. If you use a combination of the 
 | [`level-rocksdb`][level-rocksdb]             | `rocks-level`                        | `RocksLevel`              | _Not yet available_                      |
 | [`rocksdb`][rocksdb]                         | `rocks-level`                        | `RocksLevel`              | _Not yet available_                      |
 | [`multileveldown`][multileveldown]           | [`many-level`][many-level]           | `ManyLevelGuest`          | [`many-level@1`][many-level@1]           |
-| [`level-party`][level-party]                 | [`rave-level`][rave-level]           | `RaveLevel`               | _Not yet available_                      |
+| [`level-party`][level-party]                 | [`rave-level`][rave-level]           | `RaveLevel`               | [`rave-level@1`][rave-level@1]           |
 | [`subleveldown`][subleveldown]<sup>1</sup>   | n/a                                  | n/a                       | [`abstract-level@1`][abstract-level@1]   |
 | [`deferred-leveldown`][def-ld]<sup>1</sup>   | n/a                                  | n/a                       | [`abstract-level@1`][abstract-level@1]   |
 | [`encoding-down`][encoding-down]<sup>1</sup> | n/a                                  | n/a                       | [`abstract-level@1`][abstract-level@1]   |
@@ -326,6 +326,8 @@ Support us with a monthly donation on [Open Collective](https://opencollective.c
 [multileveldown]: https://github.com/Level/multileveldown
 
 [rave-level]: https://github.com/Level/rave-level
+
+[rave-level@1]: https://github.com/Level/rave-level/blob/main/UPGRADING.md#100
 
 [rocksdb]: https://github.com/Level/rocksdb
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ Support us with a monthly donation on [Open Collective](https://opencollective.c
 
 [multileveldown]: https://github.com/Level/multileveldown
 
+[rave-level]: https://github.com/Level/rave-level
+
 [rocksdb]: https://github.com/Level/rocksdb
 
 [subleveldown]: https://github.com/Level/subleveldown

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To upgrade, please consult the following table. If you use a combination of the 
 | [`level-rocksdb`][level-rocksdb]             | `rocks-level`                        | `RocksLevel`              | _Not yet available_                      |
 | [`rocksdb`][rocksdb]                         | `rocks-level`                        | `RocksLevel`              | _Not yet available_                      |
 | [`multileveldown`][multileveldown]           | [`many-level`][many-level]           | `ManyLevelGuest`          | [`many-level@1`][many-level@1]           |
-| [`level-party`][level-party]                 | `rave-level`                         | `RaveLevel`               | _Not yet available_                      |
+| [`level-party`][level-party]                 | [`rave-level`][rave-level]           | `RaveLevel`               | _Not yet available_                      |
 | [`subleveldown`][subleveldown]<sup>1</sup>   | n/a                                  | n/a                       | [`abstract-level@1`][abstract-level@1]   |
 | [`deferred-leveldown`][def-ld]<sup>1</sup>   | n/a                                  | n/a                       | [`abstract-level@1`][abstract-level@1]   |
 | [`encoding-down`][encoding-down]<sup>1</sup> | n/a                                  | n/a                       | [`abstract-level@1`][abstract-level@1]   |


### PR DESCRIPTION
Hi! I spent a while looking at level-party before realizing that rave-level does exist. These changes just add a link to the rave-level repo from the upgrade table.